### PR TITLE
Custom function prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ _Example response_
 By default this middleware will prefix all the methods with `res` generating methods with signatures of `res200`, `res404`, etc... This prefix can be customized to your usage prefences by providing a prefix string to the module when use it as middleware.
 
 __Example custom prefix__
-	
-	const responses = require('response-express-middlware')
+  
+    const responses = require('response-express-middlware')
     app.use(responses('send'))
     
     // Response method signatures will now be

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This is intended as global middleware to be added before any route handling.
     const responses = require('response-express-middlware')
     
     // Register middleware
-    app.use(responses)
+    app.use(responses())
 
 This will register methods onto the `res` object in the form of `res200`, `res404`, etc... Each method takes 2 parameters, a custom message and an object of options to override the default model. 
 
@@ -52,6 +52,20 @@ _Example response_
       data: [{...}],
       error: ''
     }
+
+### Custom Prefix
+
+By default this middleware will prefix all the methods with `res` generating methods with signatures of `res200`, `res404`, etc... This prefix can be customized to your usage prefences by providing a prefix string to the module when use it as middleware.
+
+__Example custom prefix__
+	
+	const responses = require('response-express-middlware')
+    app.use(responses('send'))
+    
+    // Response method signatures will now be
+    // registered like this.
+    res.send200()
+
 
 ## Developing
 

--- a/index.js
+++ b/index.js
@@ -2,11 +2,14 @@
 
 const codes = [200, 201, 202, 400, 401, 402, 403, 404, 408, 500, 501, 502]
 
-module.exports = (req, res, next) => {
-  codes.forEach((code) => {
-    let response = require(`./${code}`)
-    res[`res${code}`] = response.bind(res)
-  })
+module.exports = function response(prefix) {
+  prefix = prefix || 'res'
+  return (req, res, next) => {
+    codes.forEach((code) => {
+      let response = require(`./${code}`)
+      res[`${prefix}${code}`] = response.bind(res)
+    })
 
-  next()
+    next()
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "response-express-middleware",
-  "version": "1.0.1",
+  "version": "1.1.1",
   "description": "Standardizes and structures express.js responses",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Allows users to specific a custom prefix for their response method signatures. e.g.

```
const responses = require('response-express-middlware')
app.use(responses('myCustomSig'))
res.myCustomSig200
```
